### PR TITLE
Font Library support for S3, CDNs, immutable file systems, atomic deployments, etc

### DIFF
--- a/.github/workflows/phpunit.yaml
+++ b/.github/workflows/phpunit.yaml
@@ -16,6 +16,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3']
         wp-versions: [ 'trunk' ]

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -17,7 +17,7 @@ function bootstrap() {
 	add_filter( 'font_dir', __NAMESPACE__ . '\\filter_default_font_directory' );
 
 	/*
-	 * Prime the uploads cache hook.
+	 * Prime the uploads directory cache.
 	 *
 	 * This runs late on the `init` hook to allow time for plugins to register
 	 * custom upload directory file handlers.

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -15,8 +15,14 @@ namespace PWCC\FontsToUploads;
  */
 function bootstrap() {
 	add_filter( 'font_dir', __NAMESPACE__ . '\\filter_default_font_directory' );
-	// Prime the cache.
-	add_action( 'init', __NAMESPACE__ . '\\cached_wp_get_upload_dir' );
+
+	/*
+	 * Prime the uploads cache hook.
+	 *
+	 * This runs late on the `init` hook to allow time for plugins to register
+	 * custom upload directory file handlers.
+	 */
+	add_action( 'init', __NAMESPACE__ . '\\cached_wp_get_upload_dir', 20 );
 }
 
 /**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -35,6 +35,8 @@ function bootstrap() {
  * Without a primed cache, `wp_get_upload_dir()` would trigger the a call
  * to `wp_get_font_dir()` which would trigger a call to `wp_get_upload_dir()`.
  *
+ * @see https://github.com/pantheon-systems/pantheon-mu-plugin/blob/main/inc/fonts.php for inspiration.
+ *
  * @return array Result of wp_get_upload_dir().
  */
 function cached_wp_get_upload_dir() {

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -14,5 +14,29 @@ namespace PWCC\FontsToUploads;
  * Bootstrap the plugin.
  */
 function bootstrap() {
+	add_filter( 'font_dir', __NAMESPACE__ . '\\filter_default_font_directory' );
 }
 
+/**
+ * Filter the WordPress default font directory to use the uploads folder.
+ *
+ * Relocated files uploaded by the Font Library from `wp-content/fonts/` to a
+ * sub-directory of the uploads folder.
+ *
+ * @param array $font_directory The default in which to store fonts.
+ * @return array The modified fonts directory.
+ */
+function filter_default_font_directory( $font_directory ) {
+	$upload_dir = wp_get_upload_dir();
+
+	$font_directory = array(
+		'path'    => untrailingslashit( $upload_dir['basedir'] ) . '/wp-fonts',
+		'url'     => untrailingslashit( $upload_dir['baseurl'] ) . '/wp-fonts',
+		'subdir'  => '',
+		'basedir' => untrailingslashit( $upload_dir['basedir'] ) . '/wp-fonts',
+		'baseurl' => untrailingslashit( $upload_dir['baseurl'] ) . '/wp-fonts',
+		'error'   => false,
+	);
+
+	return $font_directory;
+}

--- a/tests/class-test-fonts-to-uploads.php
+++ b/tests/class-test-fonts-to-uploads.php
@@ -15,9 +15,33 @@ use WP_UnitTestCase;
 class Test_Fonts_To_Uploads extends WP_UnitTestCase {
 
 	/**
-	 * Ensure tests are running.
+	 * Ensure font directory begins with uploads base path.
+	 *
+	 * @dataProvider data_font_directory_begins_with_upload_base_path
+	 *
+	 * @param string       $key         The key to compare.
+	 * @param string|false $uploads_key The uploads key to check against.
 	 */
-	public function test_sample() {
-		$this->assertTrue( true );
+	public function test_font_directory_begins_with_upload_base_path( $key, $uploads_key ) {
+		$uploads = wp_get_upload_dir();
+		$fonts   = wp_get_font_dir();
+
+		$this->assertArrayHasKey( $key, $uploads, "Uploads[{$uploads_key}] is not set." );
+		$this->assertArrayHasKey( $key, $fonts, "Fonts[{$key}] is not set." );
+		$this->assertStringStartsWith( $uploads[ $uploads_key ], $fonts[ $key ], "Fonts[{$key}] does not begin with uploads[{$uploads_key}]." );
+	}
+
+	/**
+	 * Data provider for test_font_directory_begins_with_upload_base_path
+	 *
+	 * @return array[] Data Provider
+	 */
+	public function data_font_directory_begins_with_upload_base_path() {
+		return array(
+			array( 'path', 'basedir' ),
+			array( 'url', 'baseurl' ),
+			array( 'basedir', 'basedir' ),
+			array( 'baseurl', 'baseurl' ),
+		);
 	}
 }

--- a/tests/class-test-fonts-to-uploads.php
+++ b/tests/class-test-fonts-to-uploads.php
@@ -24,15 +24,7 @@ class Test_Fonts_To_Uploads extends WP_UnitTestCase {
 			function( $upload_dir ) {
 				static $count = 0;
 				++$count;
-
-				/*
-				 * Under normal circumstances the filter will be called twice.
-				 *
-				 * Once when the upload_dir is initially requested and once when the
-				 * font directory filter runs and requests the upload directory without
-				 * the filter applied.
-				 */
-				$this->assertLessThan( 3, $count, 'Filtering uploads directory should not trigger infinite loop.' );
+				$this->assertSame( 1, $count, 'Filtering uploads directory should not trigger infinite loop.' );
 				return $upload_dir;
 			},
 			5

--- a/tests/class-test-fonts-to-uploads.php
+++ b/tests/class-test-fonts-to-uploads.php
@@ -24,7 +24,15 @@ class Test_Fonts_To_Uploads extends WP_UnitTestCase {
 			function( $upload_dir ) {
 				static $count = 0;
 				++$count;
-				$this->assertSame( 1, $count, 'Filtering uploads directory should not trigger infinite loop.' );
+
+				/*
+				 * Under normal circumstances the filter will be called twice.
+				 *
+				 * Once when the upload_dir is initially requested and once when the
+				 * font directory filter runs and requests the upload directory without
+				 * the filter applied.
+				 */
+				$this->assertLessThan( 3, $count, 'Filtering uploads directory should not trigger infinite loop.' );
 				return $upload_dir;
 			},
 			5

--- a/tests/class-test-fonts-to-uploads.php
+++ b/tests/class-test-fonts-to-uploads.php
@@ -13,6 +13,28 @@ use WP_UnitTestCase;
  * Test the rewrite rules.
  */
 class Test_Fonts_To_Uploads extends WP_UnitTestCase {
+	/**
+	 * Ensure `add_filter( 'upload_dir', 'wp_get_font_dir' );` does not trigger an infinite loop.
+	 */
+	public function test_filter_does_not_cause_infinite_loop() {
+		add_filter( 'upload_dir', 'wp_get_font_dir' );
+
+		add_filter(
+			'upload_dir',
+			function( $upload_dir ) {
+				static $count = 0;
+				++$count;
+				$this->assertSame( 1, $count, 'Filtering uploads directory should not trigger infinite loop.' );
+				return $upload_dir;
+			},
+			5
+		);
+
+		$uploads = wp_get_upload_dir();
+
+		// This will never be hit if an infinite loop is triggered.
+		$this->assertTrue( true );
+	}
 
 	/**
 	 * Ensure font directory begins with uploads base path.


### PR DESCRIPTION
Move font library files back to uploads directory.

See
* https://github.com/WordPress/gutenberg/issues/59417
* https://github.com/WordPress/gutenberg/issues/53965
* https://github.com/WordPress/gutenberg/pull/52704#discussion_r1269940796